### PR TITLE
fix: keep long press on the edited flag out of drag selection

### DIFF
--- a/presentation-feature-flags-list/src/main/java/ua/polodarb/gmsflags/presentation/feature/flagdetails/ui/components/list/FlagsGrid.kt
+++ b/presentation-feature-flags-list/src/main/java/ua/polodarb/gmsflags/presentation/feature/flagdetails/ui/components/list/FlagsGrid.kt
@@ -43,6 +43,7 @@ import ua.polodarb.gmsflags.presentation.core.ui.adaptive.LocalGmsAdaptiveLayout
 import ua.polodarb.gmsflags.presentation.core.ui.scrollbar.GridScrollbar
 import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.FlagDetailsEvent
 import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.FlagDetailsState
+import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.InlineFlagEditor
 import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.SelectedFlag
 import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.AppRemoteContentState
 import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.FlagFilter
@@ -52,6 +53,9 @@ import ua.polodarb.gmsflags.presentation.feature.flagdetails.ui.components.serve
 private val DragSelectAutoScrollEdge = 56.dp
 
 private const val DragSelectMaxScrollSpeedPxPerTick = 10f
+
+internal fun allowsDragSelection(target: SelectedFlag, openEditor: InlineFlagEditor?): Boolean =
+    openEditor == null || openEditor.name != target.name || openEditor.type != target.type
 
 private class DragSelectionSession {
     var anchorKey: SelectedFlag? = null
@@ -89,6 +93,7 @@ internal fun FlagsGrid(
         flags.associate { "${it.type}:${it.name}" to SelectedFlag(it.type, it.name) }
     }
     val selectedFlagsState = rememberUpdatedState(state.selectedFlags)
+    val inlineEditorState = rememberUpdatedState(state.inlineEditor)
     val onEventState = rememberUpdatedState(onEvent)
     val autoScrollThresholdPx = with(LocalDensity.current) { DragSelectAutoScrollEdge.toPx() }
     var autoScrollSpeed by remember { mutableFloatStateOf(0f) }
@@ -173,22 +178,28 @@ internal fun FlagsGrid(
                             detectDragGesturesAfterLongPress(
                                 onDragStart = { offset ->
                                     dragSession.pointerPosition = offset
-                                    flagAt(offset)?.let { key ->
-                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        dragSession.anchorKey = key
-                                        dragSession.lastKey = key
-                                        val selected = selectedFlagsState.value
-                                        dragSession.selecting = key !in selected
-                                        onEventState.value(
-                                            FlagDetailsEvent.DragSelectionChanged(
-                                                if (dragSession.selecting) {
-                                                    selected + key
-                                                } else {
-                                                    selected - key
-                                                },
-                                            ),
-                                        )
-                                    }
+                                    flagAt(offset)
+                                        ?.takeIf {
+                                            allowsDragSelection(it, inlineEditorState.value)
+                                        }
+                                        ?.let { key ->
+                                            haptic.performHapticFeedback(
+                                                HapticFeedbackType.LongPress,
+                                            )
+                                            dragSession.anchorKey = key
+                                            dragSession.lastKey = key
+                                            val selected = selectedFlagsState.value
+                                            dragSession.selecting = key !in selected
+                                            onEventState.value(
+                                                FlagDetailsEvent.DragSelectionChanged(
+                                                    if (dragSession.selecting) {
+                                                        selected + key
+                                                    } else {
+                                                        selected - key
+                                                    },
+                                                ),
+                                            )
+                                        }
                                 },
                                 onDragCancel = {
                                     autoScrollSpeed = 0f

--- a/presentation-feature-flags-list/src/test/java/ua/polodarb/gmsflags/presentation/feature/flagdetails/ui/components/list/FlagsGridTest.kt
+++ b/presentation-feature-flags-list/src/test/java/ua/polodarb/gmsflags/presentation/feature/flagdetails/ui/components/list/FlagsGridTest.kt
@@ -1,0 +1,41 @@
+package ua.polodarb.gmsflags.presentation.feature.flagdetails.ui.components.list
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import ua.polodarb.gmsflags.domain.flags.FlagType
+import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.InlineFlagEditor
+import ua.polodarb.gmsflags.presentation.feature.flagdetails.mvi.SelectedFlag
+
+class FlagsGridTest {
+    @Test
+    fun `long press starts drag selection when no inline editor is open`() {
+        assertTrue(allowsDragSelection(target = STRING_FLAG, openEditor = null))
+    }
+
+    @Test
+    fun `long press on the flag being edited is left to the text field`() {
+        val editor = InlineFlagEditor(name = STRING_FLAG.name, type = STRING_FLAG.type, value = "")
+
+        assertFalse(allowsDragSelection(target = STRING_FLAG, openEditor = editor))
+    }
+
+    @Test
+    fun `long press on another flag still starts drag selection while editing`() {
+        val editor = InlineFlagEditor(name = STRING_FLAG.name, type = STRING_FLAG.type, value = "")
+        val otherFlag = SelectedFlag(FlagType.String, "other_flag")
+
+        assertTrue(allowsDragSelection(target = otherFlag, openEditor = editor))
+    }
+
+    @Test
+    fun `flags sharing a name across types are told apart`() {
+        val editor = InlineFlagEditor(name = STRING_FLAG.name, type = FlagType.Integer, value = "")
+
+        assertTrue(allowsDragSelection(target = STRING_FLAG, openEditor = editor))
+    }
+
+    private companion object {
+        val STRING_FLAG = SelectedFlag(FlagType.String, "empty_string_flag")
+    }
+}


### PR DESCRIPTION
An empty String flag value could not be pasted into. Long-pressing the empty field
highlighted the flag and closed the editor instead of showing the paste toolbar.

### Cause

`FlagsGrid` installs `detectTapGestures` and `detectDragGesturesAfterLongPress` on the
`LazyVerticalGrid` itself and hit-tests by coordinates, so the gestures also fire for
long presses landing on the inline editor's `OutlinedTextField`.

Compose's text field does not consume pointer changes while waiting for its own long
press (`touchSelectionFirstPress` consumes only the drag that follows), and
`awaitLongPressOrCancellation` cancels only on a consumed change. Both gestures
therefore win: the grid emits `DragSelectionChanged`, whose reduction clears
`inlineEditor`, and the editor is torn down before its toolbar can show.

Only empty values are affected in practice. With text present, a double tap selects a
word and opens the toolbar without ever involving a long press. With no text,
`TextFieldSelectionState` early-returns on `visualText.isEmpty()` on every other path,
so long press is the only route to the paste toolbar — and that is the gesture the grid
was stealing.

### Fix

A long press landing on the flag that is currently being edited belongs to the text
field, not to drag selection. Long press on any other card still starts drag selection,
so multi-select keeps working while an editor is open. Tap needed no change: the text
field consumes it, so the grid's tap detector already cancels on its own.

### Testing

- `:presentation-feature-flags-list:testDebugUnitTest` — green, 4 new cases covering the
  predicate, including flags that share a name across types.
- Gesture behaviour itself is not covered: the module has no Robolectric or
  `ui-test-junit4`, so the grid-vs-text-field conflict cannot be reproduced on the JVM.
  Needs a manual check — open the inline editor on a String flag with an empty value,
  long-press the field, expect the paste toolbar and no card highlight.
